### PR TITLE
Update faq.html

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -52,9 +52,9 @@
                   <div id="collapse1" class="panel-collapse collapse">
                     <div class="panel-body">
                         <p><strong>Option 1</strong>: Es gibt bereits ein Freifunk-Netz in Reichweite</p>
-                        <p>Besorge dir ein Router <a target="_blank" href="https://wiki.freifunk-rhein-neckar.de/hardware/unterstuetzte_geraete">(Liste der unterstützten Modelle)</a>, spiele die Freifunk-Firmware auf, schließe ihn an die Steckdose an und los gehts! Wenn du auch einen Teil deines Internetanschlusses für Freifunk freigeben willst, verbinde den Freifunk Router zusätzlich per Netzwerkkabel mit deinem Internet-Router.</p>
+                        <p>Besorge dir ein Router <a target="_blank" href="https://wiki.freifunk-rhein-neckar.de/hardware:unterstuetzte_geraete">(Liste der unterstützten Modelle)</a>, spiele die Freifunk-Firmware auf, schließe ihn an die Steckdose an und los gehts! Wenn du auch einen Teil deines Internetanschlusses für Freifunk freigeben willst, verbinde den Freifunk Router zusätzlich per Netzwerkkabel mit deinem Internet-Router.</p>
                         <p><strong>Option 2</strong>: Es gibt noch kein Freifunk-Netz in Reichweite</p>
-                        <p>Besorge dir ein Router <a target="_blank" href="https://wiki.freifunk-rhein-neckar.de/hardware/unterstuetzte_geraete">(Liste der unterstützten Modelle)</a>, spiele die Freifunk-Firmware auf, schließe ihn an die Steckdose und deinen Router an und los gehts!</p>
+                        <p>Besorge dir ein Router <a target="_blank" href="https://wiki.freifunk-rhein-neckar.de/hardware:unterstuetzte_geraete">(Liste der unterstützten Modelle)</a>, spiele die Freifunk-Firmware auf, schließe ihn an die Steckdose und deinen Router an und los gehts!</p>
                     </div>
                   </div>
                 </div>
@@ -158,7 +158,7 @@
                   </div>
                   <div id="collapse7" class="panel-collapse collapse">
                     <div class="panel-body">
-                        <p>In unserem Wiki findest du eine  <a target="_blank" href="https://wiki.freifunk-rhein-neckar.de/hardware/unterstuetzte_geraete">Liste</a> mit allen zur Zeit getesten Geräten. In der Regel funktioniert aber fast alle Router die von OpenWRT unterstützt werden. Der bekannte WRT54GL wird leider nicht mehr unterstützt.</p>
+                        <p>In unserem Wiki findest du eine  <a target="_blank" href="https://wiki.freifunk-rhein-neckar.de/hardware:unterstuetzte_geraete">Liste</a> mit allen zur Zeit getesten Geräten. In der Regel funktioniert aber fast alle Router die von OpenWRT unterstützt werden. Der bekannte WRT54GL wird leider nicht mehr unterstützt.</p>
 
                     </div>
                   </div>


### PR DESCRIPTION
Broken link - 3x https://wiki.freifunk-rhein-neckar.de/hardware/unterstuetzte_geraete zu https://wiki.freifunk-rhein-neckar.de/hardware:unterstuetzte_geraete geändert